### PR TITLE
Refactor GSON objects and improve artifact detection

### DIFF
--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/PullRequestCommands.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/PullRequestCommands.kt
@@ -17,6 +17,7 @@ import java.awt.Color
 import java.io.File
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+import kotlin.time.Duration.Companion.days
 
 @Suppress("ReturnCount")
 class PullRequestCommands(config: BotConfig, commands: Commands) {
@@ -84,6 +85,11 @@ class PullRequestCommands(config: BotConfig, commands: Commands) {
         val job = github.getRun(lastCommit, "Build and test") ?: run {
             val text = "${title}${time} \nUnable to locate run \uD83E\uDD7A (expired or does not exist)"
             reply(embed(embedTitle, text, readColor(pr)))
+            return
+        }
+
+        if (job.startedAt?.let { toTimeMark(it).passedSince() > 90.days } == true) {
+            reply(embed(embedTitle, "${title}${time} \nLast build for PR #$prNumber has expired \uD83E\uDD7A", readColor(pr)))
             return
         }
 

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/github/GitHubClient.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/github/GitHubClient.kt
@@ -1,6 +1,7 @@
 package at.hannibal2.skyhanni.discord.github
 
 import at.hannibal2.skyhanni.discord.json.discord.Artifact
+import at.hannibal2.skyhanni.discord.json.discord.CheckRun
 import at.hannibal2.skyhanni.discord.json.discord.PullRequestJson
 import at.hannibal2.skyhanni.discord.utils.GithubUtils
 import java.io.File
@@ -11,11 +12,15 @@ class GitHubClient(private val owner: String, private val repo: String, private 
         return GithubUtils.findArtifact(owner, repo, lastCommit, token)
     }
 
-    fun downloadArtifact(artifactId: Long, outputFile: File) {
+    fun downloadArtifact(artifactId: Int, outputFile: File) {
         GithubUtils.downloadArtifact(owner, repo, artifactId, outputFile, token)
     }
 
     fun findPullRequest(prNumber: Int): PullRequestJson? {
         return GithubUtils.findPullRequest(owner, repo, prNumber, token)
+    }
+
+    fun getRun(lastCommit: String, checkName: String): CheckRun? {
+        return GithubUtils.getRunsFromCommit(owner, repo, lastCommit, checkName, token)
     }
 }

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/ArtifactResponse.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/ArtifactResponse.kt
@@ -2,30 +2,30 @@ package at.hannibal2.skyhanni.discord.json.discord
 
 import com.google.gson.annotations.SerializedName
 
-data class ArtifactResponse(
+data class ArtifactResponse (
     @SerializedName("total_count") val totalCount: Int,
-    val artifacts: List<Artifact>
+    @SerializedName("artifacts") val artifacts: List<Artifact>
 )
 
-data class Artifact(
-    val id: Long,
+data class Artifact (
+    @SerializedName("id") val id: Int,
     @SerializedName("node_id") val nodeId: String,
-    val name: String,
+    @SerializedName("name") val name: String,
     @SerializedName("size_in_bytes") val sizeInBytes: Int,
-    val url: String,
+    @SerializedName("url") val url: String,
     @SerializedName("archive_download_url") val archiveDownloadUrl: String,
-    val expired: Boolean,
-    val digest: String,
-    @SerializedName("created_at") val createdAt: String,
-    @SerializedName("updated_at") val updatedAt: String,
-    @SerializedName("expires_at") val expiresAt: String,
-    @SerializedName("workflow_run") val workflowRun: WorkflowRun
+    @SerializedName("expired") val expired: Boolean,
+    @SerializedName("created_at") val createdAt: String?,
+    @SerializedName("expires_at") val expiresAt: String?,
+    @SerializedName("updated_at") val updatedAt: String?,
+    @SerializedName("digest") val digest: String?,
+    @SerializedName("workflow_run") val workflowRun: WorkflowRun?
 )
 
-data class WorkflowRun(
-    val id: Long,
-    @SerializedName("repository_id") val repositoryId: Long,
-    @SerializedName("head_repository_id") val headRepositoryId: Long,
+data class WorkflowRun (
+    @SerializedName("id") val id: Int,
+    @SerializedName("repository_id") val repositoryId: Int,
+    @SerializedName("head_repository_id") val headRepositoryId: Int,
     @SerializedName("head_branch") val headBranch: String,
     @SerializedName("head_sha") val headSha: String
 )

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/CheckRunsResponse.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/CheckRunsResponse.kt
@@ -22,6 +22,7 @@ data class CheckRun (
     @SerializedName("output") val output: Output,
     @SerializedName("name") val name: String,
     @SerializedName("check_suite") val checkSuite: CheckSuite?,
+    @SerializedName("app") val app: GitHubapp?,
     @SerializedName("pull_requests") val pullRequests: List<PullRequestMinimal>,
     @SerializedName("deployment") val deployment: Deployment
 )
@@ -54,7 +55,65 @@ data class Output (
 )
 
 data class CheckSuite (
-    @SerializedName("id") val id: Int
+    @SerializedName("id") val id: Long
+)
+
+data class GitHubapp (
+    @SerializedName("id") val id: Long,
+    @SerializedName("slug") val slug: String,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("client_id") val clientId: String,
+    @SerializedName("owner") val owner: SimpleUserOrEnterprise,
+    @SerializedName("name") val name: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("external_url") val externalUrl: String,
+    @SerializedName("html_url") val htmlUrl: String,
+    @SerializedName("created_at") val createdAt: String,
+    @SerializedName("updated_at") val updatedAt: String,
+    @SerializedName("permissions") val permissions: GitHubPermissions,
+    @SerializedName("events") val events: List<String>,
+    @SerializedName("installations_count") val installationsCount: Int,
+    @SerializedName("client_secret") val clientSecret: String,
+    @SerializedName("webhook_secret") val webhookSecret: String?,
+    @SerializedName("pem") val pem: String
+)
+
+data class SimpleUserOrEnterprise (
+    @SerializedName("name") val name: String?,
+    @SerializedName("email") val email: String?,
+    @SerializedName("login") val login: String?,
+    @SerializedName("id") val id: Long,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("avatar_url") val avatarUrl: String,
+    @SerializedName("gravatar_id") val gravatarId: String?,
+    @SerializedName("url") val url: String?,
+    @SerializedName("html_url") val htmlUrl: String,
+    @SerializedName("followers_url") val followersUrl: String?,
+    @SerializedName("following_url") val followingUrl: String?,
+    @SerializedName("gists_url") val gistsUrl: String?,
+    @SerializedName("starred_url") val starredUrl: String?,
+    @SerializedName("subscriptions_url") val subscriptionsUrl: String?,
+    @SerializedName("organizations_url") val organizationsUrl: String?,
+    @SerializedName("repos_url") val reposUrl: String?,
+    @SerializedName("events_url") val eventsUrl: String?,
+    @SerializedName("received_events_url") val receivedEventsUrl: String?,
+    @SerializedName("type") val type: String?,
+    @SerializedName("site_admin") val siteAdmin: Boolean?,
+    @SerializedName("starred_at") val starredAt: String?,
+    @SerializedName("user_view_type") val userViewType: String?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("website_url") val websiteUrl: String?,
+    @SerializedName("slug") val slug: String?,
+    @SerializedName("created_at") val createdAt: String?,
+    @SerializedName("updated_at") val updatedAt: String?
+)
+
+data class GitHubPermissions (
+    @SerializedName("issues") val issues: String,
+    @SerializedName("checks") val checks: String,
+    @SerializedName("metadata") val metadata: String,
+    @SerializedName("contents") val contents: String,
+    @SerializedName("deployments") val deployments: String
 )
 
 data class PullRequestMinimal (
@@ -85,7 +144,7 @@ data class MinimalBase (
 
 data class Deployment (
     @SerializedName("url") val url: String,
-    @SerializedName("id") val id: Int,
+    @SerializedName("id") val id: Long,
     @SerializedName("node_id") val nodeId: String,
     @SerializedName("task") val task: String,
     @SerializedName("original_environment") val originalEnvironment: String,
@@ -96,5 +155,6 @@ data class Deployment (
     @SerializedName("statuses_url") val statusesUrl: String,
     @SerializedName("repository_url") val repositoryUrl: String,
     @SerializedName("transient_environment") val transientEnvironment: Boolean,
-    @SerializedName("production_environment") val productionEnvironment: Boolean
+    @SerializedName("production_environment") val productionEnvironment: Boolean,
+    @SerializedName("performed_via_github_app") val performedViaGithubApp: GitHubapp?
 )

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/CheckRunsResponse.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/CheckRunsResponse.kt
@@ -1,0 +1,100 @@
+package at.hannibal2.skyhanni.discord.json.discord
+
+import com.google.gson.annotations.SerializedName
+
+data class CheckRunsResponse (
+    @SerializedName("total_count") val totalCount: Int,
+    @SerializedName("check_runs") val checkRuns: List<CheckRun>
+)
+
+data class CheckRun (
+    @SerializedName("id") val id: Long,
+    @SerializedName("head_sha") val headSha: String,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("external_id") val externalId: String?,
+    @SerializedName("url") val url: String,
+    @SerializedName("html_url") val htmlUrl: String?,
+    @SerializedName("details_url") val detailsUrl: String?,
+    @SerializedName("status") val status: Status,
+    @SerializedName("conclusion") val conclusion: Conclusion?,
+    @SerializedName("started_at") val startedAt: String?,
+    @SerializedName("completed_at") val completedAt: String?,
+    @SerializedName("output") val output: Output,
+    @SerializedName("name") val name: String,
+    @SerializedName("check_suite") val checkSuite: CheckSuite?,
+    @SerializedName("pull_requests") val pullRequests: List<PullRequestMinimal>,
+    @SerializedName("deployment") val deployment: Deployment
+)
+
+enum class Status {
+    @SerializedName("queued") QUEUED,
+    @SerializedName("in_progress") IN_PROGRESS,
+    @SerializedName("completed") COMPLETED,
+    @SerializedName("waiting") WAITING,
+    @SerializedName("requested") REQUESTED,
+    @SerializedName("pending") PENDING
+}
+
+enum class Conclusion {
+    @SerializedName("success") SUCCESS,
+    @SerializedName("failure") FAILURE,
+    @SerializedName("neutral") NEUTRAL,
+    @SerializedName("cancelled") CANCELLED,
+    @SerializedName("skipped") SKIPPED,
+    @SerializedName("timed_out") TIMED_OUT,
+    @SerializedName("action_required") ACTION_REQUIRED
+}
+
+data class Output (
+    @SerializedName("title") val title: String?,
+    @SerializedName("summary") val summary: String?,
+    @SerializedName("text") val text: String?,
+    @SerializedName("annotations_count") val annotationsCount: Int,
+    @SerializedName("annotations_url") val annotationsUrl: String
+)
+
+data class CheckSuite (
+    @SerializedName("id") val id: Int
+)
+
+data class PullRequestMinimal (
+    @SerializedName("id") val id: Long,
+    @SerializedName("number") val number: Int,
+    @SerializedName("url") val url: String,
+    @SerializedName("head") val head: MinimalHead,
+    @SerializedName("base") val base: MinimalBase
+)
+
+data class MinimalHead (
+    @SerializedName("ref") val ref: String,
+    @SerializedName("sha") val sha: String,
+    @SerializedName("repo") val repo: MinimalRepo
+)
+
+data class MinimalRepo (
+    @SerializedName("id") val id: Long,
+    @SerializedName("url") val url: String,
+    @SerializedName("name") val name: String
+)
+
+data class MinimalBase (
+    @SerializedName("ref") val ref: String,
+    @SerializedName("sha") val sha: String,
+    @SerializedName("repo") val repo: MinimalRepo
+)
+
+data class Deployment (
+    @SerializedName("url") val url: String,
+    @SerializedName("id") val id: Int,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("task") val task: String,
+    @SerializedName("original_environment") val originalEnvironment: String,
+    @SerializedName("environment") val environment: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("created_at") val createdAt: String,
+    @SerializedName("updated_at") val updatedAt: String,
+    @SerializedName("statuses_url") val statusesUrl: String,
+    @SerializedName("repository_url") val repositoryUrl: String,
+    @SerializedName("transient_environment") val transientEnvironment: Boolean,
+    @SerializedName("production_environment") val productionEnvironment: Boolean
+)

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/JobsResponse.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/JobsResponse.kt
@@ -22,7 +22,7 @@ data class Job (
     @SerializedName("started_at") val startedAt: String,
     @SerializedName("completed_at") val completedAt: String?,
     @SerializedName("name") val name: String,
-    @SerializedName("steps") val steps: List<Steps>,
+    @SerializedName("steps") val steps: List<Step>,
     @SerializedName("check_run_url") val checkRunUrl: String,
     @SerializedName("labels") val labels: List<String>,
     @SerializedName("runner_id") val runnerId: Int?,
@@ -33,8 +33,8 @@ data class Job (
     @SerializedName("head_branch") val headBranch: String?
 )
 
-data class Steps (
-    @SerializedName("status") val status: Status5,
+data class Step (
+    @SerializedName("status") val status: StepStatus,
     @SerializedName("conclusion") val conclusion: String?,
     @SerializedName("name") val name: String,
     @SerializedName("number") val number: Int,
@@ -42,7 +42,7 @@ data class Steps (
     @SerializedName("completed_at") val completedAt: String?
 )
 
-enum class Status5 {
+enum class StepStatus {
     @SerializedName("queued") QUEUED,
     @SerializedName("in_progress") IN_PROGRESS,
     @SerializedName("completed") COMPLETED

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/JobsResponse.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/JobsResponse.kt
@@ -2,42 +2,48 @@ package at.hannibal2.skyhanni.discord.json.discord
 
 import com.google.gson.annotations.SerializedName
 
-data class JobsResponse(
+data class JobsResponse (
     @SerializedName("total_count") val totalCount: Int,
     @SerializedName("jobs") val jobs: List<Job>
 )
 
-data class Job(
-    @SerializedName("id") val id: Long,
-    @SerializedName("run_id") val runId: Long,
-    @SerializedName("workflow_name") val workflowName: String,
-    @SerializedName("head_branch") val headBranch: String,
+data class Job (
+    @SerializedName("id") val id: Int,
+    @SerializedName("run_id") val runId: Int,
     @SerializedName("run_url") val runUrl: String,
     @SerializedName("run_attempt") val runAttempt: Int,
     @SerializedName("node_id") val nodeId: String,
     @SerializedName("head_sha") val headSha: String,
     @SerializedName("url") val url: String,
-    @SerializedName("html_url") val htmlUrl: String,
-    @SerializedName("status") val status: String,
-    @SerializedName("conclusion") val conclusion: String,
+    @SerializedName("html_url") val htmlUrl: String?,
+    @SerializedName("status") val status: Status,
+    @SerializedName("conclusion") val conclusion: Conclusion?,
     @SerializedName("created_at") val createdAt: String,
     @SerializedName("started_at") val startedAt: String,
-    @SerializedName("completed_at") val completedAt: String,
+    @SerializedName("completed_at") val completedAt: String?,
     @SerializedName("name") val name: String,
-    @SerializedName("steps") val steps: List<Step>,
+    @SerializedName("steps") val steps: List<Steps>,
     @SerializedName("check_run_url") val checkRunUrl: String,
     @SerializedName("labels") val labels: List<String>,
-    @SerializedName("runner_id") val runnerId: Long?,
+    @SerializedName("runner_id") val runnerId: Int?,
     @SerializedName("runner_name") val runnerName: String?,
-    @SerializedName("runner_group_id") val runnerGroupId: Long?,
-    @SerializedName("runner_group_name") val runnerGroupName: String?
+    @SerializedName("runner_group_id") val runnerGroupId: Int?,
+    @SerializedName("runner_group_name") val runnerGroupName: String?,
+    @SerializedName("workflow_name") val workflowName: String?,
+    @SerializedName("head_branch") val headBranch: String?
 )
 
-data class Step(
+data class Steps (
+    @SerializedName("status") val status: Status5,
+    @SerializedName("conclusion") val conclusion: String?,
     @SerializedName("name") val name: String,
-    @SerializedName("status") val status: String,
-    @SerializedName("conclusion") val conclusion: String,
     @SerializedName("number") val number: Int,
-    @SerializedName("started_at") val startedAt: String,
-    @SerializedName("completed_at") val completedAt: String
+    @SerializedName("started_at") val startedAt: String?,
+    @SerializedName("completed_at") val completedAt: String?
 )
+
+enum class Status5 {
+    @SerializedName("queued") QUEUED,
+    @SerializedName("in_progress") IN_PROGRESS,
+    @SerializedName("completed") COMPLETED
+}

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/PullRequestJson.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/PullRequestJson.kt
@@ -2,72 +2,68 @@ package at.hannibal2.skyhanni.discord.json.discord
 
 import com.google.gson.annotations.SerializedName
 
-data class PullRequestJson(
-    val url: String,
-    val id: Long,
+data class PullRequestJson (
+    @SerializedName("url") val url: String,
+    @SerializedName("id") val id: Long,
     @SerializedName("node_id") val nodeId: String,
     @SerializedName("html_url") val htmlUrl: String,
     @SerializedName("diff_url") val diffUrl: String,
     @SerializedName("patch_url") val patchUrl: String,
     @SerializedName("issue_url") val issueUrl: String,
-    val number: Int,
-    val state: String,
-    val locked: Boolean,
-    val title: String,
-    val user: User,
-    val body: String,
-    @SerializedName("created_at") val createdAt: String,
-    @SerializedName("updated_at") val updatedAt: String,
-    @SerializedName("closed_at") val closedAt: String?,
-    @SerializedName("merged_at") val mergedAt: String?,
-    @SerializedName("merge_commit_sha") val mergeCommitSha: String,
-    val assignee: User?,
-    val assignees: List<User>,
-    @SerializedName("requested_reviewers") val requestedReviewers: List<User>,
-    @SerializedName("requested_teams") val requestedTeams: List<Any>,
-    val labels: List<Any>,
-    val milestone: Any?,
-    val draft: Boolean,
     @SerializedName("commits_url") val commitsUrl: String,
     @SerializedName("review_comments_url") val reviewCommentsUrl: String,
     @SerializedName("review_comment_url") val reviewCommentUrl: String,
     @SerializedName("comments_url") val commentsUrl: String,
     @SerializedName("statuses_url") val statusesUrl: String,
-    val head: PullRequestBranch,
-    val base: PullRequestBranch,
-    @SerializedName("_links") val links: Links,
-    @SerializedName("author_association") val authorAssociation: String,
-    @SerializedName("auto_merge") val autoMerge: Any?,
-    @SerializedName("active_lock_reason") val activeLockReason: Any?,
-    val merged: Boolean,
-    val mergeable: Boolean,
-    val rebaseable: Boolean,
+    @SerializedName("number") val number: Int,
+    @SerializedName("state") val state: State,
+    @SerializedName("locked") val locked: Boolean,
+    @SerializedName("title") val title: String,
+    @SerializedName("user") val user: SimpleUser,
+    @SerializedName("body") val body: String?,
+    @SerializedName("labels") val labels: List<Labels>,
+    @SerializedName("active_lock_reason") val activeLockReason: String?,
+    @SerializedName("created_at") val createdAt: String,
+    @SerializedName("updated_at") val updatedAt: String,
+    @SerializedName("closed_at") val closedAt: String?,
+    @SerializedName("merged_at") val mergedAt: String?,
+    @SerializedName("merge_commit_sha") val mergeCommitSha: String?,
+    @SerializedName("assignees") val assignees: List<SimpleUser?>,
+    @SerializedName("requested_reviewers") val requestedReviewers: List<SimpleUser?>,
+    @SerializedName("requested_teams") val requestedTeams: List<TeamSimple?>,
+    @SerializedName("head") val head: Head,
+    @SerializedName("base") val base: Base,
+    @SerializedName("_links") val Links: Links,
+    @SerializedName("author_association") val authorAssociation: AuthorAssociation,
+    @SerializedName("auto_merge") val autoMerge: Automerge?,
+    @SerializedName("draft") val draft: Boolean,
+    @SerializedName("merged") val merged: Boolean,
+    @SerializedName("mergeable") val mergeable: Boolean?,
+    @SerializedName("rebaseable") val rebaseable: Boolean?,
     @SerializedName("mergeable_state") val mergeableState: String,
-    @SerializedName("merged_by") val mergedBy: User?,
-    val comments: Int,
+    @SerializedName("comments") val comments: Int,
     @SerializedName("review_comments") val reviewComments: Int,
     @SerializedName("maintainer_can_modify") val maintainerCanModify: Boolean,
-    val commits: Int,
-    val additions: Int,
-    val deletions: Int,
+    @SerializedName("commits") val commits: Int,
+    @SerializedName("additions") val additions: Int,
+    @SerializedName("deletions") val deletions: Int,
     @SerializedName("changed_files") val changedFiles: Int
 )
 
-data class PullRequestBranch(
-    val label: String,
-    val ref: String,
-    val sha: String,
-    val user: User,
-    val repo: Repo
-)
+enum class State {
+    @SerializedName("open") OPEN,
+    @SerializedName("closed") CLOSED
+}
 
-data class User(
-    val login: String,
-    val id: Long,
+data class SimpleUser (
+    @SerializedName("name") val name: String?,
+    @SerializedName("email") val email: String?,
+    @SerializedName("login") val login: String,
+    @SerializedName("id") val id: Long,
     @SerializedName("node_id") val nodeId: String,
     @SerializedName("avatar_url") val avatarUrl: String,
-    @SerializedName("gravatar_id") val gravatarId: String,
-    val url: String,
+    @SerializedName("gravatar_id") val gravatarId: String?,
+    @SerializedName("url") val url: String,
     @SerializedName("html_url") val htmlUrl: String,
     @SerializedName("followers_url") val followersUrl: String,
     @SerializedName("following_url") val followingUrl: String,
@@ -78,112 +74,216 @@ data class User(
     @SerializedName("repos_url") val reposUrl: String,
     @SerializedName("events_url") val eventsUrl: String,
     @SerializedName("received_events_url") val receivedEventsUrl: String,
-    val type: String,
-    @SerializedName("user_view_type") val userViewType: String?,
-    @SerializedName("site_admin") val siteAdmin: Boolean
+    @SerializedName("type") val type: String,
+    @SerializedName("site_admin") val siteAdmin: Boolean,
+    @SerializedName("starred_at") val starredAt: String,
+    @SerializedName("user_view_type") val userViewType: String
 )
 
-data class Repo(
-    val id: Long,
+data class Labels (
+    @SerializedName("id") val id: Long,
     @SerializedName("node_id") val nodeId: String,
-    val name: String,
-    @SerializedName("full_name") val fullName: String,
-    val private: Boolean,
-    val owner: User,
+    @SerializedName("url") val url: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("color") val color: String,
+    @SerializedName("default") val default: Boolean
+)
+
+data class TeamSimple (
+    @SerializedName("id") val id: Int,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("url") val url: String,
+    @SerializedName("members_url") val membersUrl: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("permission") val permission: String,
+    @SerializedName("privacy") val privacy: String,
+    @SerializedName("notification_setting") val notificationSetting: String,
     @SerializedName("html_url") val htmlUrl: String,
-    val description: String?,
-    val fork: Boolean,
-    val url: String,
-    @SerializedName("forks_url") val forksUrl: String,
-    @SerializedName("keys_url") val keysUrl: String,
-    @SerializedName("collaborators_url") val collaboratorsUrl: String,
-    @SerializedName("teams_url") val teamsUrl: String,
-    @SerializedName("hooks_url") val hooksUrl: String,
-    @SerializedName("issue_events_url") val issueEventsUrl: String,
-    @SerializedName("events_url") val eventsUrl: String,
-    @SerializedName("assignees_url") val assigneesUrl: String,
-    @SerializedName("branches_url") val branchesUrl: String,
-    @SerializedName("tags_url") val tagsUrl: String,
-    @SerializedName("blobs_url") val blobsUrl: String,
-    @SerializedName("git_tags_url") val gitTagsUrl: String,
-    @SerializedName("git_refs_url") val gitRefsUrl: String,
-    @SerializedName("trees_url") val treesUrl: String,
-    @SerializedName("statuses_url") val statusesUrl: String,
-    @SerializedName("languages_url") val languagesUrl: String,
-    @SerializedName("stargazers_url") val stargazersUrl: String,
-    @SerializedName("contributors_url") val contributorsUrl: String,
-    @SerializedName("subscribers_url") val subscribersUrl: String,
-    @SerializedName("subscription_url") val subscriptionUrl: String,
-    @SerializedName("commits_url") val commitsUrl: String,
-    @SerializedName("git_commits_url") val gitCommitsUrl: String,
-    @SerializedName("comments_url") val commentsUrl: String,
-    @SerializedName("issue_comment_url") val issueCommentUrl: String,
-    @SerializedName("contents_url") val contentsUrl: String,
-    @SerializedName("compare_url") val compareUrl: String,
-    @SerializedName("merges_url") val mergesUrl: String,
+    @SerializedName("repositories_url") val repositoriesUrl: String,
+    @SerializedName("slug") val slug: String,
+    @SerializedName("ldap_dn") val ldapDn: String
+)
+
+data class Head (
+    @SerializedName("label") val label: String,
+    @SerializedName("ref") val ref: String,
+    @SerializedName("repo") val repo: Repository,
+    @SerializedName("sha") val sha: String,
+    @SerializedName("user") val user: SimpleUser
+)
+
+data class Repository (
+    @SerializedName("id") val id: Long,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("full_name") val fullName: String,
+    @SerializedName("forks") val forks: Int,
+    @SerializedName("permissions") val permissions: Permissions,
+    @SerializedName("owner") val owner: SimpleUser,
+    @SerializedName("private") val private: Boolean,
+    @SerializedName("html_url") val htmlUrl: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("fork") val fork: Boolean,
+    @SerializedName("url") val url: String,
     @SerializedName("archive_url") val archiveUrl: String,
+    @SerializedName("assignees_url") val assigneesUrl: String,
+    @SerializedName("blobs_url") val blobsUrl: String,
+    @SerializedName("branches_url") val branchesUrl: String,
+    @SerializedName("collaborators_url") val collaboratorsUrl: String,
+    @SerializedName("comments_url") val commentsUrl: String,
+    @SerializedName("commits_url") val commitsUrl: String,
+    @SerializedName("compare_url") val compareUrl: String,
+    @SerializedName("contents_url") val contentsUrl: String,
+    @SerializedName("contributors_url") val contributorsUrl: String,
+    @SerializedName("deployments_url") val deploymentsUrl: String,
     @SerializedName("downloads_url") val downloadsUrl: String,
+    @SerializedName("events_url") val eventsUrl: String,
+    @SerializedName("forks_url") val forksUrl: String,
+    @SerializedName("git_commits_url") val gitCommitsUrl: String,
+    @SerializedName("git_refs_url") val gitRefsUrl: String,
+    @SerializedName("git_tags_url") val gitTagsUrl: String,
+    @SerializedName("git_url") val gitUrl: String,
+    @SerializedName("issue_comment_url") val issueCommentUrl: String,
+    @SerializedName("issue_events_url") val issueEventsUrl: String,
     @SerializedName("issues_url") val issuesUrl: String,
-    @SerializedName("pulls_url") val pullsUrl: String,
+    @SerializedName("keys_url") val keysUrl: String,
+    @SerializedName("labels_url") val labelsUrl: String,
+    @SerializedName("languages_url") val languagesUrl: String,
+    @SerializedName("merges_url") val mergesUrl: String,
     @SerializedName("milestones_url") val milestonesUrl: String,
     @SerializedName("notifications_url") val notificationsUrl: String,
-    @SerializedName("labels_url") val labelsUrl: String,
+    @SerializedName("pulls_url") val pullsUrl: String,
     @SerializedName("releases_url") val releasesUrl: String,
-    @SerializedName("deployments_url") val deploymentsUrl: String,
-    @SerializedName("created_at") val createdAt: String,
-    @SerializedName("updated_at") val updatedAt: String,
-    @SerializedName("pushed_at") val pushedAt: String,
-    @SerializedName("git_url") val gitUrl: String,
     @SerializedName("ssh_url") val sshUrl: String,
+    @SerializedName("stargazers_url") val stargazersUrl: String,
+    @SerializedName("statuses_url") val statusesUrl: String,
+    @SerializedName("subscribers_url") val subscribersUrl: String,
+    @SerializedName("subscription_url") val subscriptionUrl: String,
+    @SerializedName("tags_url") val tagsUrl: String,
+    @SerializedName("teams_url") val teamsUrl: String,
+    @SerializedName("trees_url") val treesUrl: String,
     @SerializedName("clone_url") val cloneUrl: String,
+    @SerializedName("mirror_url") val mirrorUrl: String?,
+    @SerializedName("hooks_url") val hooksUrl: String,
     @SerializedName("svn_url") val svnUrl: String,
-    val homepage: String?,
-    val size: Int,
+    @SerializedName("homepage") val homepage: String?,
+    @SerializedName("language") val language: String?,
+    @SerializedName("forks_count") val forksCount: Int,
     @SerializedName("stargazers_count") val stargazersCount: Int,
     @SerializedName("watchers_count") val watchersCount: Int,
-    val language: String?,
+    @SerializedName("size") val size: Int,
+    @SerializedName("default_branch") val defaultBranch: String,
+    @SerializedName("open_issues_count") val openIssuesCount: Int,
+    @SerializedName("is_template") val isTemplate: Boolean,
+    @SerializedName("topics") val topics: List<String>,
     @SerializedName("has_issues") val hasIssues: Boolean,
     @SerializedName("has_projects") val hasProjects: Boolean,
-    @SerializedName("has_downloads") val hasDownloads: Boolean,
     @SerializedName("has_wiki") val hasWiki: Boolean,
     @SerializedName("has_pages") val hasPages: Boolean,
+    @SerializedName("has_downloads") val hasDownloads: Boolean,
     @SerializedName("has_discussions") val hasDiscussions: Boolean,
-    @SerializedName("forks_count") val forksCount: Int,
-    @SerializedName("mirror_url") val mirrorUrl: String?,
-    val archived: Boolean,
-    val disabled: Boolean,
-    @SerializedName("open_issues_count") val openIssuesCount: Int,
-    val license: License?,
+    @SerializedName("archived") val archived: Boolean,
+    @SerializedName("disabled") val disabled: Boolean,
+    @SerializedName("visibility") val visibility: String,
+    @SerializedName("pushed_at") val pushedAt: String?,
+    @SerializedName("created_at") val createdAt: String?,
+    @SerializedName("updated_at") val updatedAt: String?,
+    @SerializedName("allow_rebase_merge") val allowRebaseMerge: Boolean,
+    @SerializedName("temp_clone_token") val tempCloneToken: String,
+    @SerializedName("allow_squash_merge") val allowSquashMerge: Boolean,
+    @SerializedName("allow_auto_merge") val allowAutoMerge: Boolean,
+    @SerializedName("delete_branch_on_merge") val deleteBranchOnMerge: Boolean,
+    @SerializedName("allow_update_branch") val allowUpdateBranch: Boolean,
+    @SerializedName("use_squash_pr_title_as_default") val useSquashPrTitleAsDefault: Boolean,
+    @SerializedName("squash_merge_commit_title") val squashMergeCommitTitle: SquashMergeCommitTitle,
+    @SerializedName("squash_merge_commit_message") val squashMergeCommitMessage: SquashMergeCommitMessage,
+    @SerializedName("merge_commit_title") val mergeCommitTitle: MergeCommitTitle,
+    @SerializedName("merge_commit_message") val mergeCommitMessage: MergeCommitMessage,
+    @SerializedName("allow_merge_commit") val allowMergeCommit: Boolean,
     @SerializedName("allow_forking") val allowForking: Boolean,
-    @SerializedName("is_template") val isTemplate: Boolean,
     @SerializedName("web_commit_signoff_required") val webCommitSignoffRequired: Boolean,
-    val topics: List<String>,
-    val visibility: String,
-    val forks: Int,
     @SerializedName("open_issues") val openIssues: Int,
-    val watchers: Int,
-    @SerializedName("default_branch") val defaultBranch: String
+    @SerializedName("watchers") val watchers: Int,
+    @SerializedName("master_branch") val masterBranch: String,
+    @SerializedName("starred_at") val starredAt: String,
+    @SerializedName("anonymous_access_enabled") val anonymousAccessEnabled: Boolean
 )
 
-data class License(
-    val key: String,
-    val name: String,
-    @SerializedName("spdx_id") val spdxId: String,
-    val url: String,
-    @SerializedName("node_id") val nodeId: String
+data class Permissions (
+    @SerializedName("admin") val admin: Boolean,
+    @SerializedName("pull") val pull: Boolean,
+    @SerializedName("triage") val triage: Boolean,
+    @SerializedName("push") val push: Boolean,
+    @SerializedName("maintain") val maintain: Boolean
 )
 
-data class Links(
-    val self: Link,
-    val html: Link,
-    val issue: Link,
-    val comments: Link,
+enum class SquashMergeCommitTitle {
+    @SerializedName("PR_TITLE") PR_TITLE,
+    @SerializedName("COMMIT_OR_PR_TITLE") COMMIT_OR_PR_TITLE
+}
+
+enum class SquashMergeCommitMessage {
+    @SerializedName("PR_BODY") PR_BODY,
+    @SerializedName("COMMIT_MESSAGES") COMMIT_MESSAGES,
+    @SerializedName("BLANK") BLANK
+}
+
+enum class MergeCommitTitle {
+    @SerializedName("PR_TITLE") PR_TITLE,
+    @SerializedName("MERGE_MESSAGE") MERGE_MESSAGE
+}
+
+enum class MergeCommitMessage {
+    @SerializedName("PR_BODY") PR_BODY,
+    @SerializedName("PR_TITLE") PR_TITLE,
+    @SerializedName("BLANK") BLANK
+}
+
+data class Base (
+    @SerializedName("label") val label: String,
+    @SerializedName("ref") val ref: String,
+    @SerializedName("repo") val repo: Repository,
+    @SerializedName("sha") val sha: String,
+    @SerializedName("user") val user: SimpleUser
+)
+
+data class Links (
+    @SerializedName("comments") val comments: Link,
+    @SerializedName("commits") val commits: Link,
+    @SerializedName("statuses") val statuses: Link,
+    @SerializedName("html") val html: Link,
+    @SerializedName("issue") val issue: Link,
     @SerializedName("review_comments") val reviewComments: Link,
     @SerializedName("review_comment") val reviewComment: Link,
-    val commits: Link,
-    val statuses: Link
+    @SerializedName("self") val self: Link
 )
 
-data class Link(
-    val href: String
+data class Link (
+    @SerializedName("href") val href: String
 )
+
+enum class AuthorAssociation {
+    @SerializedName("COLLABORATOR") COLLABORATOR,
+    @SerializedName("CONTRIBUTOR") CONTRIBUTOR,
+    @SerializedName("FIRST_TIMER") FIRST_TIMER,
+    @SerializedName("FIRST_TIME_CONTRIBUTOR") FIRST_TIME_CONTRIBUTOR,
+    @SerializedName("MANNEQUIN") MANNEQUIN,
+    @SerializedName("MEMBER") MEMBER,
+    @SerializedName("NONE") NONE,
+    @SerializedName("OWNER") OWNER
+}
+
+data class Automerge (
+    @SerializedName("enabled_by") val enabledBy: SimpleUser,
+    @SerializedName("merge_method") val mergeMethod: MergeMethod,
+    @SerializedName("commit_title") val commitTitle: String,
+    @SerializedName("commit_message") val commitMessage: String
+)
+
+enum class MergeMethod {
+    @SerializedName("merge") MERGE,
+    @SerializedName("squash") SQUASH,
+    @SerializedName("rebase") REBASE
+}

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/PullRequestJson.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/json/discord/PullRequestJson.kt
@@ -22,15 +22,17 @@ data class PullRequestJson (
     @SerializedName("user") val user: SimpleUser,
     @SerializedName("body") val body: String?,
     @SerializedName("labels") val labels: List<Labels>,
+    @SerializedName("milestone") val milestone: Milestone?,
     @SerializedName("active_lock_reason") val activeLockReason: String?,
     @SerializedName("created_at") val createdAt: String,
     @SerializedName("updated_at") val updatedAt: String,
     @SerializedName("closed_at") val closedAt: String?,
     @SerializedName("merged_at") val mergedAt: String?,
     @SerializedName("merge_commit_sha") val mergeCommitSha: String?,
-    @SerializedName("assignees") val assignees: List<SimpleUser?>,
-    @SerializedName("requested_reviewers") val requestedReviewers: List<SimpleUser?>,
-    @SerializedName("requested_teams") val requestedTeams: List<TeamSimple?>,
+    @SerializedName("assignee") val assignee: SimpleUser?,
+    @SerializedName("assignees") val assignees: List<SimpleUser>?,
+    @SerializedName("requested_reviewers") val requestedReviewers: List<SimpleUser>?,
+    @SerializedName("requested_teams") val requestedTeams: List<TeamSimple>?,
     @SerializedName("head") val head: Head,
     @SerializedName("base") val base: Base,
     @SerializedName("_links") val Links: Links,
@@ -41,6 +43,7 @@ data class PullRequestJson (
     @SerializedName("mergeable") val mergeable: Boolean?,
     @SerializedName("rebaseable") val rebaseable: Boolean?,
     @SerializedName("mergeable_state") val mergeableState: String,
+    @SerializedName("merged_by") val mergedBy: SimpleUser?,
     @SerializedName("comments") val comments: Int,
     @SerializedName("review_comments") val reviewComments: Int,
     @SerializedName("maintainer_can_modify") val maintainerCanModify: Boolean,
@@ -90,8 +93,32 @@ data class Labels (
     @SerializedName("default") val default: Boolean
 )
 
+data class Milestone (
+    @SerializedName("url") val url: String,
+    @SerializedName("html_url") val htmlUrl: String,
+    @SerializedName("labels_url") val labelsUrl: String,
+    @SerializedName("id") val id: Long,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("number") val number: Int,
+    @SerializedName("state") val state: MilestoneState,
+    @SerializedName("title") val title: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("creator") val creator: SimpleUser?,
+    @SerializedName("open_issues") val openIssues: Int,
+    @SerializedName("closed_issues") val closedIssues: Int,
+    @SerializedName("created_at") val createdAt: String,
+    @SerializedName("updated_at") val updatedAt: String,
+    @SerializedName("closed_at") val closedAt: String?,
+    @SerializedName("due_on") val dueOn: String?
+)
+
+enum class MilestoneState {
+    @SerializedName("open") OPEN,
+    @SerializedName("closed") CLOSED
+}
+
 data class TeamSimple (
-    @SerializedName("id") val id: Int,
+    @SerializedName("id") val id: Long,
     @SerializedName("node_id") val nodeId: String,
     @SerializedName("url") val url: String,
     @SerializedName("members_url") val membersUrl: String,
@@ -119,6 +146,7 @@ data class Repository (
     @SerializedName("node_id") val nodeId: String,
     @SerializedName("name") val name: String,
     @SerializedName("full_name") val fullName: String,
+    @SerializedName("license") val license: LicenseSimple?,
     @SerializedName("forks") val forks: Int,
     @SerializedName("permissions") val permissions: Permissions,
     @SerializedName("owner") val owner: SimpleUser,
@@ -209,6 +237,15 @@ data class Repository (
     @SerializedName("master_branch") val masterBranch: String,
     @SerializedName("starred_at") val starredAt: String,
     @SerializedName("anonymous_access_enabled") val anonymousAccessEnabled: Boolean
+)
+
+data class LicenseSimple (
+    @SerializedName("key") val key: String,
+    @SerializedName("name") val name: String,
+    @SerializedName("url") val url: String?,
+    @SerializedName("spdx_id") val spdxId: String?,
+    @SerializedName("node_id") val nodeId: String,
+    @SerializedName("html_url") val htmlUrl: String
 )
 
 data class Permissions (


### PR DESCRIPTION
Currently, only the top 100 runs are checked for the current commit hash of a PR, this commit changes this to work no matter how old the pr is, provided the "Build and test" workflow existed

Also rewrites all of the GSON structures to use the structures found on https://docs.github.com/en/rest

The changes should be tested to ensure no regressions or errors have occurred