### PR TITLE
Add Jail commands

### DIFF
--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/BotConfig.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/BotConfig.kt
@@ -10,7 +10,10 @@ data class BotConfig(
     val allowedServerId: String,
     val githubTokenOwn: String,
     val githubTokenPullRequests: String,
-    val editPermissionRoleIds: Map<String, String>,
+    val jailedRoleId: String,
+    val memberRoleId: String,
+    val jailedLogChannelId: String,
+    val editPermissionRoleIds: LinkedHashMap<String, String>,
 )
 
 object ConfigLoader {
@@ -22,7 +25,10 @@ object ConfigLoader {
 		"TODO: allowed server id",
 		"TODO: github token with sh bot repo access",
 		"TODO: github token with sh mod repo access",
-		mapOf(
+		"TODO: role id for the jailed group",
+		"TODO: role id for the member group",
+		"TODO: channel id for the jailed log channel",
+		linkedMapOf(
 			"user friendly (non important) name" to "TODO: role id"
 		)
 	)

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/Utils.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/Utils.kt
@@ -2,6 +2,7 @@ package at.hannibal2.skyhanni.discord
 
 import at.hannibal2.skyhanni.discord.utils.ErrorManager.handleError
 import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Member
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.entities.User
@@ -12,11 +13,13 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.utils.FileUpload
 import java.awt.Color
 import java.awt.Toolkit.getDefaultToolkit
+import java.awt.datatransfer.DataFlavor
 import java.io.File
 import java.text.NumberFormat
 import java.util.*
 import java.util.zip.ZipFile
 import kotlin.math.pow
+import kotlin.math.round
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
 
@@ -161,8 +164,18 @@ object Utils {
 
     fun MessageReceivedEvent.hasAdminPermissions(): Boolean {
         val member = member ?: return false
-        val allowedRoleIds = BOT.config.editPermissionRoleIds.values
-        return !member.roles.none { it.id in allowedRoleIds }
+        return member.hasStaffRole("moderator")
+    }
+
+    fun Member.hasStaffRole(name: String): Boolean {
+        val staffRoles: Map<String, String> = BOT.config.editPermissionRoleIds
+        val requiredIndex = staffRoles.keys.indexOf(name.lowercase())
+        if (requiredIndex == -1) return false
+
+        val memberRoleIds = roles.map { it.id }.toSet()
+        return staffRoles.values
+            .take(requiredIndex + 1)
+            .any { it in memberRoleIds }
     }
 
     fun MessageReceivedEvent.inBotCommandChannel() = channel.id == BOT.config.botCommandChannelId
@@ -297,7 +310,7 @@ object Utils {
     }
 
     fun readStringFromClipboard(): String? = runCatching {
-        getDefaultToolkit().systemClipboard.getData(java.awt.datatransfer.DataFlavor.stringFlavor) as String
+        getDefaultToolkit().systemClipboard.getData(DataFlavor.stringFlavor) as String
     }.getOrNull()
 
     fun User.getLinkName(): String = "<@$id>"
@@ -328,7 +341,7 @@ object Utils {
      */
     fun Double.roundTo(precision: Int): Double {
         val scale = 10.0.pow(precision)
-        return kotlin.math.round(this * scale) / scale
+        return round(this * scale) / scale
     }
 
     fun runAsync(taskName: String, executor: () -> Unit) {

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/command/JailCommand.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/command/JailCommand.kt
@@ -1,9 +1,7 @@
 package at.hannibal2.skyhanni.discord.command
 
-import at.hannibal2.skyhanni.discord.BOT
-import at.hannibal2.skyhanni.discord.Option
-import at.hannibal2.skyhanni.discord.PLEADING_FACE
-import at.hannibal2.skyhanni.discord.Utils
+import at.hannibal2.skyhanni.discord.*
+import at.hannibal2.skyhanni.discord.Utils.hasStaffRole
 import at.hannibal2.skyhanni.discord.Utils.logAction
 import at.hannibal2.skyhanni.discord.Utils.reply
 import at.hannibal2.skyhanni.discord.Utils.userError
@@ -15,14 +13,9 @@ import java.awt.Color
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-// TODO: Either move to config.json and BotConfig.kt + Utils.kt or just change the IDs to real server's.
-// Placeholder IDs for the test server
-private const val COMMUNITY_HELPER_ROLE_ID = "1510199336007631002"
-private const val JAILED_ROLE_ID           = "1510199262925819965"
-private const val JAIL_LOG_CHANNEL_ID      = "1346269715697242115"
-
-private fun MessageReceivedEvent.hasJailPermissions(): Boolean =
-    member?.roles?.any { it.id == COMMUNITY_HELPER_ROLE_ID } ?: false
+private val JAILED_ROLE_ID get() = BOT.config.jailedRoleId
+private val MEMBER_ROLE_ID get() = BOT.config.memberRoleId
+private val JAIL_LOG_CHANNEL_ID get() = BOT.config.jailedLogChannelId
 
 /**
  * Resolves a member from mentions and user Id.
@@ -41,8 +34,14 @@ private fun MessageReceivedEvent.resolveTarget(query: String): Member? {
     return null
 }
 
+private fun Member.hasJailPermissions() = hasStaffRole("community helper")
+
 private fun MessageReceivedEvent.executeJail(args: List<String>, commandName: String, purge: Boolean) {
-    if (!hasJailPermissions()) {
+    val executor = member ?: run {
+        userError("you are null")
+        return
+    }
+    if (!executor.hasJailPermissions()) {
         reply("No permissions $PLEADING_FACE")
         return
     }
@@ -59,8 +58,7 @@ private fun MessageReceivedEvent.executeJail(args: List<String>, commandName: St
         return
     }
 
-    val staffRoleIds = BOT.config.editPermissionRoleIds.values
-    if (targetMember.roles.any { it.id in staffRoleIds }) {
+    if (targetMember.hasJailPermissions()) {
         userError("You cannot jail a staff member.")
         return
     }
@@ -75,11 +73,20 @@ private fun MessageReceivedEvent.executeJail(args: List<String>, commandName: St
         return
     }
 
-    val executor = member!!
+    val memberRole = guild.getRoleById(MEMBER_ROLE_ID) ?: run {
+        userError("Member role not found in this server.")
+        return
+    }
+
     logAction("used $commandName on ${targetMember.user.name} (${targetMember.id}) — reason: $reason")
 
     guild.addRoleToMember(targetMember, jailedRole).queue(
-        {},
+        {
+            guild.removeRoleFromMember(targetMember, memberRole).queue(
+                {},
+                { error -> userError("Failed to remove Member role: ${error.message}") }
+            )
+        },
         { error -> userError("Failed to add Jailed role: ${error.message}") }
     )
 

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/command/JailCommand.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/command/JailCommand.kt
@@ -24,143 +24,151 @@ private const val JAIL_LOG_CHANNEL_ID      = "1346269715697242115"
 private fun MessageReceivedEvent.hasJailPermissions(): Boolean =
     member?.roles?.any { it.id == COMMUNITY_HELPER_ROLE_ID } ?: false
 
+/**
+ * Resolves a member from mentions and user Id.
+ * Returns null and replies with an error if not uniquely identified.
+ */
+private fun MessageReceivedEvent.resolveTarget(query: String): Member? {
+    val cleanId = query.replace(Regex("[<@!>]"), "")
+    if (cleanId.isEmpty() || !cleanId.all { it.isDigit() }) {
+        userError("Invalid user - provide a mention or userID.")
+        return null
+    }
+    val member = guild.getMemberById(cleanId)
+        ?: runCatching { guild.retrieveMemberById(cleanId).complete() }.getOrNull()
+    if (member != null) return member
+    userError("No member found with ID `$cleanId`.")
+    return null
+}
+
+private fun MessageReceivedEvent.executeJail(args: List<String>, commandName: String, purge: Boolean) {
+    if (!hasJailPermissions()) {
+        reply("No permissions $PLEADING_FACE")
+        return
+    }
+
+    if (args.size < 2) return userError("<user> <reason>")
+
+    val query = args[0]
+    val reason = args.drop(1).joinToString(" ")
+
+    val targetMember = resolveTarget(query) ?: return
+
+    if (targetMember.user.isBot) {
+        userError("You cannot jail a bot.")
+        return
+    }
+
+    val staffRoleIds = BOT.config.editPermissionRoleIds.values
+    if (targetMember.roles.any { it.id in staffRoleIds }) {
+        userError("You cannot jail a staff member.")
+        return
+    }
+
+    if (targetMember.roles.any { it.id == JAILED_ROLE_ID }) {
+        userError("${targetMember.effectiveName} is already jailed.")
+        return
+    }
+
+    val jailedRole = guild.getRoleById(JAILED_ROLE_ID) ?: run {
+        userError("Jailed role not found in this server.")
+        return
+    }
+
+    val executor = member!!
+    logAction("used $commandName on ${targetMember.user.name} (${targetMember.id}) — reason: $reason")
+
+    guild.addRoleToMember(targetMember, jailedRole).queue(
+        {},
+        { error -> userError("Failed to add Jailed role: ${error.message}") }
+    )
+
+    val eventMessage = message
+    val targetId = targetMember.id
+    val oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS)
+    val textChannel = channel.asTextChannel()
+
+    Utils.runAsync("jail-$targetId") {
+        val purgedCount: Int
+
+        if (purge) {
+            // Purge up to 30 of the target's messages from the last hour in this channel
+            val toDelete = mutableListOf<Message>()
+            var lastId = eventMessage.id
+            var keepFetching = true
+
+            while (keepFetching) {
+                val batch = textChannel.getHistoryBefore(lastId, 100).complete().retrievedHistory
+                if (batch.isEmpty()) break
+
+                for (msg in batch) {
+                    if (msg.timeCreated.toInstant().isBefore(oneHourAgo)) {
+                        keepFetching = false
+                        break
+                    }
+                    if (msg.author.id == targetId) toDelete.add(msg)
+                    if (toDelete.size >= 30) {
+                        keepFetching = false
+                        break
+                    }
+                }
+
+                lastId = batch.last().id
+            }
+
+            if (toDelete.isNotEmpty()) {
+                toDelete.chunked(100).forEach { chunk ->
+                    if (chunk.size == 1) chunk.first().delete().complete()
+                    else textChannel.deleteMessages(chunk).complete()
+                }
+            }
+
+            purgedCount = toDelete.size
+        } else {
+            purgedCount = 0
+        }
+
+        val purgeMessage = if (purgedCount > 0) " · $purgedCount message(s) purged" else ""
+        eventMessage.reply("🔒 Jailed ${targetMember.asMention}$purgeMessage. Reason: *$reason*").queue()
+
+        // Log to admin channel
+        BOT.jda.getTextChannelById(JAIL_LOG_CHANNEL_ID)?.sendMessageEmbeds(
+            EmbedBuilder()
+                .setTitle("User Jailed 🔒")
+                .setColor(Color(0xE74C3C))
+                .addField("User", "${targetMember.asMention} `${targetMember.user.name}` (${targetMember.id})", false)
+                .addField("Jailed By", "${executor.asMention} `${executor.user.name}` (${executor.id})", false)
+                .addField("Reason", reason, false)
+                .addField("Channel", textChannel.asMention, true)
+                .addField("Messages Purged", if (purge) purgedCount.toString() else "N/A", true)
+                .setTimestamp(Instant.now())
+                .build()
+        )?.queue()
+    }
+}
+
 @Suppress("unused")
 class JailCommand : BaseCommand() {
     override val name: String = "jail"
-    override val description: String = "Jails a user: assigns the Jailed role, optionally purges their recent messages, and logs the action."
+    override val description: String = "Jails a user: assigns the Jailed role and logs the action."
     override val options: List<Option> = listOf(
-        Option("user", "User ID, mention, or username."),
-        Option("purge", "Purge the user's recent messages."),
+        Option("user", "User mention or exact userID."),
         Option("reason", "Reason for jailing.")
     )
     override val userCommand: Boolean = true
 
-    override fun MessageReceivedEvent.execute(args: List<String>) {
-        if (!hasJailPermissions()) {
-            reply("No permissions $PLEADING_FACE")
-            return
-        }
+    override fun MessageReceivedEvent.execute(args: List<String>) = executeJail(args, "!jail", purge = false)
+}
 
-        if (args.size < 3) return wrongUsage("<user> <purge> <reason>")
+@Suppress("unused")
+class DJailCommand : BaseCommand() {
+    override val name: String = "djail"
+    override val description: String = "Jails a user and purges up to 30 of their recent messages from this channel."
+    override val options: List<Option> = listOf(
+        Option("user", "User mention or exact userID."),
+        Option("reason", "Reason for jailing.")
+    )
+    override val userCommand: Boolean = true
 
-        val query = args[0]
-        val purge = when (args[1].lowercase()) {
-            "true", "yes" -> true
-            "false", "no" -> false
-            else -> return userError("Invalid value for <purge>: use `true` or `false`.")
-        }
-        val reason = args.drop(2).joinToString(" ")
-
-        val targetMember = resolveTarget(query) ?: return
-
-        if (targetMember.user.isBot) {
-            userError("You cannot jail a bot.")
-            return
-        }
-
-        val staffRoleIds = BOT.config.editPermissionRoleIds.values
-        if (targetMember.roles.any { it.id in staffRoleIds }) {
-            userError("You cannot jail a staff member.")
-            return
-        }
-
-        if (targetMember.roles.any { it.id == JAILED_ROLE_ID }) {
-            userError("${targetMember.effectiveName} is already jailed.")
-            return
-        }
-
-        val jailedRole = guild.getRoleById(JAILED_ROLE_ID) ?: run {
-            userError("Jailed role not found in this server.")
-            return
-        }
-
-        val executor = member!!
-        logAction("used !jail on ${targetMember.user.name} (${targetMember.id}) — reason: $reason")
-
-        guild.addRoleToMember(targetMember, jailedRole).queue(
-            { /* purge step handles the reply */ },
-            { error -> userError("Failed to add Jailed role: ${error.message}") }
-        )
-
-        val eventMessage = message
-        val targetId = targetMember.id
-        val oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS)
-        val textChannel = channel.asTextChannel()
-
-        Utils.runAsync("jail-purge-$targetId") {
-            val purgedCount: Int
-
-            if (purge) {
-                // Purge up to 30 of the target's messages from the last hour in this channel
-                val toDelete = mutableListOf<Message>()
-                var lastId = eventMessage.id
-                var keepFetching = true
-
-                while (keepFetching) {
-                    val batch = textChannel.getHistoryBefore(lastId, 100).complete().retrievedHistory
-                    if (batch.isEmpty()) break
-
-                    for (msg in batch) {
-                        if (msg.timeCreated.toInstant().isBefore(oneHourAgo)) {
-                            keepFetching = false
-                            break
-                        }
-                        if (msg.author.id == targetId) toDelete.add(msg)
-                        if (toDelete.size >= 30) {
-                            keepFetching = false
-                            break
-                        }
-                    }
-
-                    lastId = batch.last().id
-                }
-
-                if (toDelete.isNotEmpty()) {
-                    toDelete.chunked(100).forEach { chunk ->
-                        if (chunk.size == 1) chunk.first().delete().complete()
-                        else textChannel.deleteMessages(chunk).complete()
-                    }
-                }
-
-                purgedCount = toDelete.size
-            } else {
-                purgedCount = 0
-            }
-
-            val purgeMessage = if (purgedCount > 0) " · $purgedCount message(s) purged" else ""
-            eventMessage.reply("🔒 Jailed ${targetMember.asMention}$purgeMessage. Reason: *$reason*").queue()
-
-            // Log to admin channel
-            BOT.jda.getTextChannelById(JAIL_LOG_CHANNEL_ID)?.sendMessageEmbeds(
-                EmbedBuilder()
-                    .setTitle("User Jailed $PLEADING_FACE")
-                    .setColor(Color(0xE74C3C))
-                    .addField("User", "${targetMember.asMention} `${targetMember.user.name}` (${targetMember.id})", false)
-                    .addField("Jailed By", "${executor.asMention} `${executor.user.name}` (${executor.id})", false)
-                    .addField("Reason", reason, false)
-                    .addField("Channel", textChannel.asMention, true)
-                    .addField("Messages Purged", if (purge) purgedCount.toString() else "N/A", true)
-                    .setTimestamp(Instant.now())
-                    .build()
-            )?.queue()
-        }
-    }
-
-    /**
-     * Resolves a member from mentions and user Id.
-     * Returns null and replies with an error if not uniquely identified.
-     */
-    private fun MessageReceivedEvent.resolveTarget(query: String): Member? {
-        val cleanId = query.replace(Regex("[<@!>]"), "")
-        if (cleanId.isEmpty() || !cleanId.all { it.isDigit() }) {
-            userError("Invalid user — provide a mention or numeric ID.")
-            return null
-        }
-        val member = guild.getMemberById(cleanId)
-            ?: runCatching { guild.retrieveMemberById(cleanId).complete() }.getOrNull()
-        if (member != null) return member
-        userError("No member found with ID `$cleanId`.")
-        return null
-    }
-
+    override fun MessageReceivedEvent.execute(args: List<String>) = executeJail(args, "!djail", purge = true)
 }

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/command/JailCommand.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/command/JailCommand.kt
@@ -1,0 +1,166 @@
+package at.hannibal2.skyhanni.discord.command
+
+import at.hannibal2.skyhanni.discord.BOT
+import at.hannibal2.skyhanni.discord.Option
+import at.hannibal2.skyhanni.discord.PLEADING_FACE
+import at.hannibal2.skyhanni.discord.Utils
+import at.hannibal2.skyhanni.discord.Utils.logAction
+import at.hannibal2.skyhanni.discord.Utils.reply
+import at.hannibal2.skyhanni.discord.Utils.userError
+import net.dv8tion.jda.api.EmbedBuilder
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import java.awt.Color
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+// TODO: Either move to config.json and BotConfig.kt + Utils.kt or just change the IDs to real server's.
+// Placeholder IDs for the test server
+private const val COMMUNITY_HELPER_ROLE_ID = "1510199336007631002"
+private const val JAILED_ROLE_ID           = "1510199262925819965"
+private const val JAIL_LOG_CHANNEL_ID      = "1346269715697242115"
+
+private fun MessageReceivedEvent.hasJailPermissions(): Boolean =
+    member?.roles?.any { it.id == COMMUNITY_HELPER_ROLE_ID } ?: false
+
+@Suppress("unused")
+class JailCommand : BaseCommand() {
+    override val name: String = "jail"
+    override val description: String = "Jails a user: assigns the Jailed role, optionally purges their recent messages, and logs the action."
+    override val options: List<Option> = listOf(
+        Option("user", "User ID, mention, or username."),
+        Option("purge", "Purge the user's recent messages."),
+        Option("reason", "Reason for jailing.")
+    )
+    override val userCommand: Boolean = true
+
+    override fun MessageReceivedEvent.execute(args: List<String>) {
+        if (!hasJailPermissions()) {
+            reply("No permissions $PLEADING_FACE")
+            return
+        }
+
+        if (args.size < 3) return wrongUsage("<user> <purge> <reason>")
+
+        val query = args[0]
+        val purge = when (args[1].lowercase()) {
+            "true", "yes" -> true
+            "false", "no" -> false
+            else -> return userError("Invalid value for <purge>: use `true` or `false`.")
+        }
+        val reason = args.drop(2).joinToString(" ")
+
+        val targetMember = resolveTarget(query) ?: return
+
+        if (targetMember.user.isBot) {
+            userError("You cannot jail a bot.")
+            return
+        }
+
+        val staffRoleIds = BOT.config.editPermissionRoleIds.values
+        if (targetMember.roles.any { it.id in staffRoleIds }) {
+            userError("You cannot jail a staff member.")
+            return
+        }
+
+        if (targetMember.roles.any { it.id == JAILED_ROLE_ID }) {
+            userError("${targetMember.effectiveName} is already jailed.")
+            return
+        }
+
+        val jailedRole = guild.getRoleById(JAILED_ROLE_ID) ?: run {
+            userError("Jailed role not found in this server.")
+            return
+        }
+
+        val executor = member!!
+        logAction("used !jail on ${targetMember.user.name} (${targetMember.id}) — reason: $reason")
+
+        guild.addRoleToMember(targetMember, jailedRole).queue(
+            { /* purge step handles the reply */ },
+            { error -> userError("Failed to add Jailed role: ${error.message}") }
+        )
+
+        val eventMessage = message
+        val targetId = targetMember.id
+        val oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS)
+        val textChannel = channel.asTextChannel()
+
+        Utils.runAsync("jail-purge-$targetId") {
+            val purgedCount: Int
+
+            if (purge) {
+                // Purge up to 30 of the target's messages from the last hour in this channel
+                val toDelete = mutableListOf<Message>()
+                var lastId = eventMessage.id
+                var keepFetching = true
+
+                while (keepFetching) {
+                    val batch = textChannel.getHistoryBefore(lastId, 100).complete().retrievedHistory
+                    if (batch.isEmpty()) break
+
+                    for (msg in batch) {
+                        if (msg.timeCreated.toInstant().isBefore(oneHourAgo)) {
+                            keepFetching = false
+                            break
+                        }
+                        if (msg.author.id == targetId) toDelete.add(msg)
+                        if (toDelete.size >= 30) {
+                            keepFetching = false
+                            break
+                        }
+                    }
+
+                    lastId = batch.last().id
+                }
+
+                if (toDelete.isNotEmpty()) {
+                    toDelete.chunked(100).forEach { chunk ->
+                        if (chunk.size == 1) chunk.first().delete().complete()
+                        else textChannel.deleteMessages(chunk).complete()
+                    }
+                }
+
+                purgedCount = toDelete.size
+            } else {
+                purgedCount = 0
+            }
+
+            val purgeMessage = if (purgedCount > 0) " · $purgedCount message(s) purged" else ""
+            eventMessage.reply("🔒 Jailed ${targetMember.asMention}$purgeMessage. Reason: *$reason*").queue()
+
+            // Log to admin channel
+            BOT.jda.getTextChannelById(JAIL_LOG_CHANNEL_ID)?.sendMessageEmbeds(
+                EmbedBuilder()
+                    .setTitle("User Jailed $PLEADING_FACE")
+                    .setColor(Color(0xE74C3C))
+                    .addField("User", "${targetMember.asMention} `${targetMember.user.name}` (${targetMember.id})", false)
+                    .addField("Jailed By", "${executor.asMention} `${executor.user.name}` (${executor.id})", false)
+                    .addField("Reason", reason, false)
+                    .addField("Channel", textChannel.asMention, true)
+                    .addField("Messages Purged", if (purge) purgedCount.toString() else "N/A", true)
+                    .setTimestamp(Instant.now())
+                    .build()
+            )?.queue()
+        }
+    }
+
+    /**
+     * Resolves a member from mentions and user Id.
+     * Returns null and replies with an error if not uniquely identified.
+     */
+    private fun MessageReceivedEvent.resolveTarget(query: String): Member? {
+        val cleanId = query.replace(Regex("[<@!>]"), "")
+        if (cleanId.isEmpty() || !cleanId.all { it.isDigit() }) {
+            userError("Invalid user — provide a mention or numeric ID.")
+            return null
+        }
+        val member = guild.getMemberById(cleanId)
+            ?: runCatching { guild.retrieveMemberById(cleanId).complete() }.getOrNull()
+        if (member != null) return member
+        userError("No member found with ID `$cleanId`.")
+        return null
+    }
+
+}


### PR DESCRIPTION
Allows Community Helpers to have access to !jail and !djail commands.
Both add the "Jailed" role to a select user, role would remove access to every channel and add them to a private jailed channel.
!djail also purges the last 30 messages in the last hour, useful for compromised accounts sending scams.