### PR TITLE
Fix: PR command fails with new line after it

### DIFF
--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/command/PullRequestCommand.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/command/PullRequestCommand.kt
@@ -47,7 +47,7 @@ object PullRequestCommand : BaseCommand() {
         Regex("https://github\\.com/[\\w.]+/[\\w.]+/actions/runs/(?<RunId>\\d+)/job/(?<JobId>\\d+)")
     private val pullRequestPattern = "$BASE/pull/(?<pr>\\d+)".toPattern()
     private val cleanPullRequestPattern = "#(?<pr>\\d+),?".toPattern()
-    private val whitespace = Regex("\\s+")
+    private val whitespace = "\\s+".toPattern()
     
     override fun MessageReceivedEvent.execute(args: List<String>) {
         if (args.size != 1) return wrongUsage("<number>")

--- a/src/main/kotlin/at/hannibal2/skyhanni/discord/command/PullRequestCommand.kt
+++ b/src/main/kotlin/at/hannibal2/skyhanni/discord/command/PullRequestCommand.kt
@@ -47,7 +47,8 @@ object PullRequestCommand : BaseCommand() {
         Regex("https://github\\.com/[\\w.]+/[\\w.]+/actions/runs/(?<RunId>\\d+)/job/(?<JobId>\\d+)")
     private val pullRequestPattern = "$BASE/pull/(?<pr>\\d+)".toPattern()
     private val cleanPullRequestPattern = "#(?<pr>\\d+),?".toPattern()
-
+    private val whitespace = Regex("\\s+")
+    
     override fun MessageReceivedEvent.execute(args: List<String>) {
         if (args.size != 1) return wrongUsage("<number>")
         val first = args.first().removePrefix("#")
@@ -342,7 +343,7 @@ object PullRequestCommand : BaseCommand() {
         }
 
         val foundPrs = mutableListOf<Int>()
-        for (line in message.split(" ")) {
+        for (line in message.split(whitespace)) {
             val matcher = cleanPullRequestPattern.matcher(line)
             if (matcher.matches()) {
                 val pr = matcher.group("pr").toIntOrNull() ?: continue


### PR DESCRIPTION
it didn't detect new line as a whitespace seperator, and only space.
This is a lazy solution since probably better to just NOT split it at all and just change the regex and use findAll, but this works and is probably good enough.