### PR TITLE
Update Elite website URL

### DIFF
--- a/data/discord_servers.json
+++ b/data/discord_servers.json
@@ -465,7 +465,7 @@
       "id": "1096051612373487687",
       "size": "33095",
       "invite": "https://discord.gg/farms",
-      "description": "A community for top farmers and a farming weight website. <https://elitebot.dev/>",
+      "description": "A community for top farmers and a farming weight website. <https://eliteskyblock.com/>",
       "aliases": [
         "farmers",
         "EliteFarmers",


### PR DESCRIPTION
The old one still works as a redirect, but might as well update it.